### PR TITLE
Add details on Zeiss' tube lens

### DIFF
--- a/tube_lens.html
+++ b/tube_lens.html
@@ -37,7 +37,7 @@
   <tr><td>Mitutoyo</td>	<td>MT-1</td>  		<td>200</td>	<td>30</td>     <td>24</td>	   <td>436 - 656</td>	<td>?</td>      </tr>
   <tr><td>Nikon</td>	<td>MXA20696</td>  	<td>200</td>	<td>26.5</td> 	<td>32</td>	   <td>400 - 700</td>	<td>Full</td>	</tr>
   <tr><td>Olympus</td>	<td>SWTLU-C</td> 	<td>180</td>	<td>26.5</td> 	<td>36</td>	   <td>400 - 700</td>	<td>Full</td>	</tr>
-  <tr><td>Zeiss</td>	<td>?</td> 			<td>165</td>	<td></td> 	 	<td></td>	   <td></td>			<td>Partial</td>	</tr>
+  <tr><td>Zeiss</td>	<td>425308-0000-000</td> 			<td>164.5</td>	<td>25</td> 	 	<td>31.6</td>	   <td>380 - 700</td>			<td>Partial</td>	</tr>
 </table>
 	
 	<p>


### PR DESCRIPTION
Add details for Zeiss' tube lens using information from patent US7289271B2 (figure 2).